### PR TITLE
Always start modes with initial settings

### DIFF
--- a/Super_Simple_RGB_WiFi_Lamp/LEDs.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/LEDs.ino
@@ -56,6 +56,12 @@ void adjustBrightness() {
         // Clear the LEDs
         FastLED.clear();
 
+        // Initialize state of the new mode
+        auto modeIter = modes.find(Mode);
+        if (modeIter != modes.end()) {
+          modeIter->second->initialize();
+        }
+
         // Set the currentMode to Mode
         currentMode = Mode;
         modeChangeFadeAmount = 0;

--- a/Super_Simple_RGB_WiFi_Lamp/ModeBellCurve.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeBellCurve.ino
@@ -1,11 +1,14 @@
 class ModeBellCurve : public ModeBase
 {
 private:
+    // Config
     int bellCurveRed   = 128;
     int bellCurveGreen = 128;
     int bellCurveBlue  = 128;
 public:
     ModeBellCurve() {}
+    virtual void initialize() {}
+
     virtual void render() {
         // Set the top brightness
         for (int i = 0; i < topNumLeds; i++) {

--- a/Super_Simple_RGB_WiFi_Lamp/ModeCircle.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeCircle.ino
@@ -1,9 +1,14 @@
 class ModeCircle : public ModeBase
 {
 private:
-    int circleActiveLedNumber = 0;
+    int circleActiveLedNumber;
 public:
     ModeCircle() {}
+
+    virtual void initialize() {
+        circleActiveLedNumber = 0;
+    }
+
     virtual void render() {
         // First bring our logical arrays into a list of led numbers to iterate over
         int i;

--- a/Super_Simple_RGB_WiFi_Lamp/ModeClock.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeClock.ino
@@ -1,16 +1,25 @@
 class ModeClock : public ModeBase
 {
 private:
+    // Config
     int clockHourRed                 = 128;
     int clockHourGreen               = 128;
     int clockHourBlue                = 128;
     int clockMinRed                  = 128;
     int clockMinGreen                = 128;
     int clockMinBlue                 = 128;
-    int clockOnPauseBrightness       = 255;
-    unsigned long lastClockExecution = 0;
+
+    // State
+    int clockOnPauseBrightness;
+    unsigned long lastClockExecution;
 public:
     ModeClock() {}
+
+    virtual void initialize() {
+        clockOnPauseBrightness = 255;
+        lastClockExecution = 0;
+    }
+
     virtual void render() {
         if (ntpTimeSet) {
             // Get the number of seconds between each LED

--- a/Super_Simple_RGB_WiFi_Lamp/ModeColorWipe.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeColorWipe.ino
@@ -1,15 +1,24 @@
 class ModeColorWipe : public ModeBase
 {
 private:
-    int colorWipePosition             = -1;
-    bool TurningOn                    = true;
-    int colorWipeRed                  = 255;
-    int colorWipeGreen                = 0;
-    int colorWipeBlue                 = 255;
-    int colorWipeSpeed                = 20;
+    // State
+    int colorWipePosition;
+    bool TurningOn;
+
+    // Config
+    int colorWipeRed   = 255;
+    int colorWipeGreen = 0;
+    int colorWipeBlue  = 255;
+    int colorWipeSpeed = 20;
 
 public:
     ModeColorWipe() {}
+
+    virtual void initialize() {
+        colorWipePosition = -1;
+        TurningOn         = true;
+    }
+
     virtual void render() {
         EVERY_N_MILLISECONDS(colorWipeSpeed) {
             colorWipePosition++;

--- a/Super_Simple_RGB_WiFi_Lamp/ModeColour.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeColour.ino
@@ -1,11 +1,14 @@
 class ModeColour : public ModeBase
 {
 private:
+    // Config
     int colourRed   = 128;
     int colourGreen = 128;
     int colourBlue  = 128;
 public:
     ModeColour() {}
+    virtual void initialize() {}
+
     virtual void render() {
         fill_solid(ledString, NUM_LEDS, CRGB(colourRed, colourGreen, colourBlue));
     }

--- a/Super_Simple_RGB_WiFi_Lamp/ModeConfetti.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeConfetti.ino
@@ -1,12 +1,21 @@
 class ModeConfetti : public ModeBase
 {
 private:
-    bool confettiActive = true;
+    // State
+    bool confettiActive;
+    int confettiPixel;
+
+    // Config
     int confettiSpeed = 100;
-    int confettiPixel = random(NUM_LEDS);
 
 public:
     ModeConfetti() {}
+
+    virtual void initialize() {
+        confettiActive = true;
+        confettiPixel = random(NUM_LEDS);
+    }
+
     virtual void render() {
         EVERY_N_MILLISECONDS(confettiSpeed) {
           if (confettiActive) {

--- a/Super_Simple_RGB_WiFi_Lamp/ModeNightRider.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeNightRider.ino
@@ -1,12 +1,20 @@
 class ModeNightRider : public ModeBase
 {
 private:
-    int nightRiderTopLedNumber    = 0;
-    int nightRiderBottomLedNumber = 0;
-    int nightRiderTopIncrement    = 1;
-    int nightRiderBottomIncrement = 1;
+    int nightRiderTopLedNumber;
+    int nightRiderBottomLedNumber;
+    int nightRiderTopIncrement;
+    int nightRiderBottomIncrement;
 public:
     ModeNightRider() {}
+
+    virtual void initialize() {
+        nightRiderTopLedNumber    = 0;
+        nightRiderBottomLedNumber = 0;
+        nightRiderTopIncrement    = 1;
+        nightRiderBottomIncrement = 1;
+    }
+
     virtual void render() {
         int delayTime = 500 / topNumLeds;
         EVERY_N_MILLISECONDS(delayTime) {

--- a/Super_Simple_RGB_WiFi_Lamp/ModeRainbow.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeRainbow.ino
@@ -1,12 +1,21 @@
 class ModeRainbow : public ModeBase
 {
 private:
-    int rainbowStartHue   = 0;
-    int rainbowSpeed      = 10;
-    int rainbowBri        = 100;
-    float rainbowAddedHue = 0;
+    // Config
+    int rainbowStartHue = 0;
+    int rainbowSpeed    = 10;
+    int rainbowBri      = 100;
+
+    // State
+    float rainbowAddedHue;
+
 public:
     ModeRainbow() {}
+
+    virtual void initialize() {
+        rainbowAddedHue = 0;
+    }
+
     virtual void render() {
         int startHue = rainbowStartHue;
         int speed = rainbowSpeed;

--- a/Super_Simple_RGB_WiFi_Lamp/ModeSparkle.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeSparkle.ino
@@ -2,14 +2,24 @@ class ModeSparkle : public ModeBase
 {
 
 private:
-    int sparkleSpeed   = 30;
-    bool sparkleActive = true;
-    int sparkleRed     = 128;
-    int sparkleGreen   = 128;
-    int sparkleBlue    = 128;
-    int sparklePixel   = random(NUM_LEDS);
+    // Config
+    int sparkleSpeed  = 30;
+    int sparkleRed    = 128;
+    int sparkleGreen  = 128;
+    int sparkleBlue   = 128;
+
+    // State
+    bool sparkleActive;
+    int sparklePixel;
+
 public:
     ModeSparkle() {}
+
+    virtual void initialize() {
+        sparkleActive = true;
+        sparklePixel  = random(NUM_LEDS);
+    }
+
     virtual void render() {
         EVERY_N_MILLISECONDS(sparkleSpeed) {
             if (sparkleActive) {

--- a/Super_Simple_RGB_WiFi_Lamp/ModeVisualiser.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/ModeVisualiser.ino
@@ -3,20 +3,29 @@
 class ModeVisualiser : public ModeBase
 {
 private:
+    // State
     ADC_MODE(ADC_TOUT);
     arduinoFFT FFT = arduinoFFT();
     double visualiserRealSamples[VISUALISER_NUM_SAMPLES];
     double visualiserImaginarySamples[VISUALISER_NUM_SAMPLES];
-    unsigned long visualiserLastSampleTime      = 0;
-    uint16_t visualiserPeriod                   = 250;
-    uint16_t visualiserMinThreshold             = 100;
-    uint16_t visualiserMaxThreshold             = 750;
-    uint8_t visualiserNumBinsToSkip             = 3;
-    uint8_t visualiserFadeUp                    = 32;
-    uint8_t visualiserFadeDown                  = 32;
-    uint8_t visualiserHueOffset                 = 170;
+    unsigned long visualiserLastSampleTime;
+    uint8_t visualiserNumBinsToSkip;
+
+    // Config
+    uint16_t visualiserPeriod        = 250;
+    uint16_t visualiserMinThreshold  = 100;
+    uint16_t visualiserMaxThreshold  = 750;
+    uint8_t visualiserFadeUp         = 32;
+    uint8_t visualiserFadeDown       = 32;
+    uint8_t visualiserHueOffset      = 170;
 public:
     ModeVisualiser() {}
+
+    virtual void initialize() {
+        visualiserLastSampleTime = 0;
+        visualiserNumBinsToSkip  = 3;
+    }
+
     virtual void render() {
         // Only use visualiser when not trying to access the NTP server
         if (((WiFi.isConnected() && ntpTimeSet) || softApStarted) && !webSocketConnecting) {

--- a/Super_Simple_RGB_WiFi_Lamp/Super_Simple_RGB_WiFi_Lamp.ino
+++ b/Super_Simple_RGB_WiFi_Lamp/Super_Simple_RGB_WiFi_Lamp.ino
@@ -57,7 +57,13 @@ String Password = "";
 class ModeBase
 {
 public:
+    /// Override this to initialize state specific variables
+    virtual void initialize();
+
+    // Is called once per frame to update the LEDs
     virtual void render();
+
+    // Update config member variables based on the handed over settings
     virtual void applyConfig(JsonVariant& settings);
 };
 


### PR DESCRIPTION
In previous versions the board kept runtime information per mode
when switching between modes. This could have odd effects, for
example the "color wipe" mode could be invisible for some time
when it was in the "fade out" phase when switching to the mode.