### PR TITLE
Basic config for different editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Project root editor config
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+max_line_length = 100


### PR DESCRIPTION
I recognized you are working with a two-space indent. A lot of my changes were made with 4.
To reduce the diff sizes and get a bit more consistent coding style I propose to add a .editorconfig
which is automatically respected by a lot of IDEs.